### PR TITLE
update for tex2img 2.4.0

### DIFF
--- a/tex2img.rb
+++ b/tex2img.rb
@@ -2,9 +2,9 @@ class Tex2img < Formula
   desc "Compile TeX file to various formats of image"
   homepage "https://tex2img.tech/"
 
-  version "2.3.0"
-  url "https://tex2img.tech/latest/tex2imgcMac2.3.0.zip"
-  sha256 "99febf5eebe25f2069fa218579738ad49ef48d96c0dd179318275e9071425efa"
+  version "2.4.0"
+  url "https://tex2img.tech/latest/tex2imgcMac2.4.0.zip"
+  sha256 "01492e6f0e2495443ece7e124322759a413611ca87f3914f8e74d013b305afa9"
 
   def install
     # abort if not macOS


### PR DESCRIPTION
CUI版を 2.4.0 にアップデートしました。（要求OSバージョンが 10.9+ に引き上げとなっております。）